### PR TITLE
blog: add openfeature adoption story post

### DIFF
--- a/blog/2023-06-22-openfeature-adoption-story.md
+++ b/blog/2023-06-22-openfeature-adoption-story.md
@@ -1,7 +1,7 @@
 ---
 slug: 'openfeature-adoption-story'
 title: 'OpenFeature Adoption Story'
-date: 2023-06-27
+date: 2023-06-22
 authors: [liran2000]
 description: "OpenFeature is an open standard for feature-flagging. This is an adoption story."
 tags: [client, sdk, adoption]

--- a/blog/2023-06-27-openfeature-adoption-story.md
+++ b/blog/2023-06-27-openfeature-adoption-story.md
@@ -14,6 +14,8 @@ During thinking on how to define the exposed interfaces, while keeping it simple
 Gladly, the mentioned feature management cloud service created provider implementation for OpenFeature.  
 Let me explain why and how it was adopted.
 
+<!--truncate-->
+
 ## Why Feature Management was needed
 
 Our product needed a solution for feature flags:
@@ -104,7 +106,12 @@ sequenceDiagram
 Some thoughts raised during the adoption:
 * Feature Flags Configuration  
   Considering this as the provider configuration of feature flags, e.g.  
-  ```feature1=enabled, feature2=enabled by 50% split, feature3=disabled, feature4=enabled by customerId=4```  
+  ```
+  feature1=enabled
+  feature2=enabled by 50% split
+  feature3=disabled
+  feature4=enabled by customerId=4
+  ```  
   This configuration can be represented as a scheme.  
   I was thinking whether this configuration to be part of the standard. See [Slack discussion](https://cloud-native.slack.com/archives/C0344AANLA1/p1684776996586969?thread_ts=1684774617.486109&cid=C0344AANLA1) and example [flagd-definitions](https://github.com/open-feature/schemas/blob/main/json/flagd-definitions.json)
 * Flags registration  

--- a/blog/2023-06-27-openfeature-adoption-story.md
+++ b/blog/2023-06-27-openfeature-adoption-story.md
@@ -53,7 +53,7 @@ A common action is provider initialization. As it was vendor specific, it was do
 Open Feature lately added [Initialization](https://github.com/open-feature/spec/blob/main/specification/sections/02-providers.md#24-initialization) to the spec. This could have make it more standard implementation.
 
 ## Fetching flags
-We needed an option for fetching all enabled flags from the feature management service. This was not included at OpenFeature at the time, see example at [Flag Retrieval discussion](https://github.com/open-feature/ofep/issues/13#issuecomment-1337889563).
+We used an option for fetching all enabled flags from the feature management service. This was not included at OpenFeature at the time, see example at [Flag Retrieval discussion](https://github.com/open-feature/ofep/issues/13#issuecomment-1337889563).
 
 ## SDK used functionalities
 OpenFeature SDK has several used functionalities. What used for our case:
@@ -66,7 +66,7 @@ OpenFeature SDK has several used functionalities. What used for our case:
 
 ```mermaid
 sequenceDiagram
-  participant SDK
+  participant SDK as SDK (server-side)
   participant features as Features Service
   actor request as User Request
   participant developer as Developer
@@ -113,7 +113,9 @@ Some thoughts raised during the adoption:
   feature4=enabled by customerId=4
   ```  
   This configuration can be represented as a scheme.  
-  I was thinking whether this configuration to be part of the standard. See [Slack discussion](https://cloud-native.slack.com/archives/C0344AANLA1/p1684776996586969?thread_ts=1684774617.486109&cid=C0344AANLA1) and example [flagd-definitions](https://github.com/open-feature/schemas/blob/main/json/flagd-definitions.json).
+  I was thinking whether this configuration to be part of the standard. If so, it might be beneficial for import/export configurations accross vendors.
+  See [Slack discussion](https://cloud-native.slack.com/archives/C0344AANLA1/p1684776996586969?thread_ts=1684774617.486109&cid=C0344AANLA1) and example [flagd-definitions](https://github.com/open-feature/schemas/blob/main/json/flagd-definitions.json).
+* Fetch all flags - see [Fetching flags](#fetching-flags)
 * Flags registration  
   Some providers exposing initial flags registration via their SDK. Wondering how does it go with OpenFeature spec.
 

--- a/blog/2023-06-27-openfeature-adoption-story.md
+++ b/blog/2023-06-27-openfeature-adoption-story.md
@@ -40,7 +40,7 @@ This can tell me that the OpenFeature standard is making sense.
 ## How OpenFeature was adopted
 As for this context OpenFeature can be treated as a "bridge", it was used accordingly:
 * OpenFeature provider initializer was added.
-* Generic OpenFeature wrapper was created.
+* Generic OpenFeature client wrapper was created.
 
 ## Monitoring
 As our provider was fetching feature flags configuration and receiving real-time configuration changes, we needed to know its status and provide an alert on scenarios like service is down or communication failure.  
@@ -57,12 +57,12 @@ We needed an option for fetching all enabled flags from the feature management s
 
 ## SDK used functionalities
 OpenFeature SDK has several used functionalities. What used for our case:
-* evaluation via OpenFeature Client (getBooleanEvaluation with context and similar for other types)
-* Initialization - see [Initialization](./Initialization)
-* Events - see [Monitoring](./Monitoring)
-* Fetch all flags - see [Fetching flags](./Fetching flags)
+* Evaluation via OpenFeature Client (getBooleanEvaluation with context and similar for other types)
+* Initialization - see [Initialization](#initialization)
+* Events - see [Monitoring](#monitoring)
+* Fetch all flags - see [Fetching flags](#fetching-flags)
 
-###  Features Management SDK
+###  Features Management SDK - example flow
 
 ```mermaid
 sequenceDiagram
@@ -85,7 +85,7 @@ sequenceDiagram
   note left of SDK: OpenFeature method
   end
   SDK->>request: true/false from cache
-  SDK->>features: <stream> fetch conf changes events https:...
+  SDK->>features: <stream> fetch config changes events https://...
   features->>SDK: OK
   note left of features: fetch config changes responses
   developer->>features: Change feature flag value
@@ -97,7 +97,7 @@ sequenceDiagram
   rect rgb(30,144,255)
   note left of SDK: OpenFeature Error event
   end
-  SDK->>metrics: Features Service status=Error
+  SDK->metrics: Features Service status=Error
   request->>SDK: getBooleanEvaluation
   SDK->>request: true/false from cache
 ```
@@ -113,7 +113,7 @@ Some thoughts raised during the adoption:
   feature4=enabled by customerId=4
   ```  
   This configuration can be represented as a scheme.  
-  I was thinking whether this configuration to be part of the standard. See [Slack discussion](https://cloud-native.slack.com/archives/C0344AANLA1/p1684776996586969?thread_ts=1684774617.486109&cid=C0344AANLA1) and example [flagd-definitions](https://github.com/open-feature/schemas/blob/main/json/flagd-definitions.json)
+  I was thinking whether this configuration to be part of the standard. See [Slack discussion](https://cloud-native.slack.com/archives/C0344AANLA1/p1684776996586969?thread_ts=1684774617.486109&cid=C0344AANLA1) and example [flagd-definitions](https://github.com/open-feature/schemas/blob/main/json/flagd-definitions.json).
 * Flags registration  
   Some providers exposing initial flags registration via their SDK. Wondering how does it go with OpenFeature spec.
 

--- a/blog/2023-06-27-openfeature-adoption-story.md
+++ b/blog/2023-06-27-openfeature-adoption-story.md
@@ -1,0 +1,112 @@
+---
+slug: 'openfeature-adoption-story'
+title: 'OpenFeature Adoption Story'
+date: 2023-06-27
+authors: [liran2000]
+description: "OpenFeature is an open standard for feature-flagging. This is an adoption story."
+tags: [client, sdk, adoption]
+draft: false
+---
+
+Our team recently needed to use one of the large feature management cloud services.  
+This service had a documented SDK with usage guidelines.  
+During thinking on how to define the exposed interfaces, while keeping it simple and generic, I started doing some research, and encountered [OpenFeature](https://openfeature.dev).  
+Gladly, the mentioned feature management cloud service created provider implementation for OpenFeature.  
+Let me explain why and how it was adopted.
+
+## Why Feature Management was needed
+
+Our product needed a solution for feature flags:
+* providing a gradual release mechanism and a simple way to define target audiences such as target group or split release
+* Using feature flags for dynamic configuration values which can be changed in runtime dynamically without needing for a new release deployment.
+* Ability for A/B testing - can be done via feature for specific region, specific users etc'.
+
+## Why OpenFeature was chosen to be used
+
+While keeping it simple and generic, I had a few wonders:
+* How to name the method
+* How to do provide information for error handling
+* What response structure to define
+* How to define properties passed to the methods
+OpenFeature solved me all these questions with its standard. When using a standard, I have good reasons why it is defined like this, as the standard supports it.
+
+## Feature Management Cloud Service Provider Implementation For OpenFeature
+Although the provider implementation is used transparantly, as it is open sourced, I explored its implementation.  
+What I saw is that the provider implementation is very short and simple, acting like a "bridge" from OpenFeature to the feature management cloud service specific vendor SDK which was already exist.  
+This can tell me that the OpenFeature standard is making sense.
+
+## How OpenFeature was adopted
+As for this context OpenFeature can be treated as a "bridge", it was used accordingly:
+* OpenFeature provider initializer was added.
+* Generic OpenFeature wrapper was created.
+
+## Monitoring
+As our provider was fetching feature flags configuration and receiving real-time configuration changes, we needed to know its status and provide an alert on scenarios like service is down or communication failure.  
+When adoption was done, OpenFeature did not support that functionallity.  
+Open Feature lately added [Events](https://github.com/open-feature/spec/blob/main/specification/sections/05-events.md#5-events). Together with provider events implementation, it could have given us this functionallity.  
+To overcome the missing events enhancement, we implemented it directly via provider abilities. It did cause some mix between OpenFeature and vendor specific implementation.
+
+## Initialization
+A common action is provider initialization. As it was vendor specific, it was done by provider call implementation.  
+Open Feature lately added [Initialization](https://github.com/open-feature/spec/blob/main/specification/sections/02-providers.md#24-initialization) to the spec. This could have make it more standard implementation.
+
+## Fetching flags
+We needed an option for fetching all enabled flags from the feature management service. This was not included at OpenFeature at the time, see example at [Flag Retrieval discussion](https://github.com/open-feature/ofep/issues/13#issuecomment-1337889563).
+
+## SDK used functionalities
+OpenFeature SDK has several used functionalities. What used for our case:
+* evaluation via OpenFeature Client (getBooleanEvaluation with context and similar for other types)
+* Initialization - see [Initialization](./Initialization)
+* Events - see [Monitoring](./Monitoring)
+* Fetch all flags - see [Fetching flags](./Fetching flags)
+
+###  Features Management SDK
+
+```mermaid
+sequenceDiagram
+  participant SDK
+  participant features as Features Service
+  actor request as User Request
+  participant developer as Developer
+  participant metrics as Metrics Provider
+  note left of SDK: initialize
+  rect rgb(30,144,255)
+  note left of SDK: OpenFeature method
+  end
+  SDK->>features: fetch config https://...
+  rect rgb(127,255,0)
+  features->>SDK: Feature Flags configuration JSON
+  end
+  note left of SDK: save config in cache
+  request->>SDK: getBooleanEvaluation
+  rect rgb(30,144,255)
+  note left of SDK: OpenFeature method
+  end
+  SDK->>request: true/false from cache
+  SDK->>features: <stream> fetch conf changes events https:...
+  features->>SDK: OK
+  note left of features: fetch config changes responses
+  developer->>features: Change feature flag value
+  features->>SDK: Changed event
+  SDK->>features: fetch config https://...
+  rect rgb(255,0,0)
+  features->>SDK: Error
+  end
+  rect rgb(30,144,255)
+  note left of SDK: OpenFeature Error event
+  end
+  SDK->>metrics: Features Service status=Error
+  request->>SDK: getBooleanEvaluation
+  SDK->>request: true/false from cache
+```
+
+## Misc.
+Some thoughts raised during the adoption:
+* Feature Flags Configuration  
+  Considering this as the provider configuration of feature flags, e.g.  
+  ```feature1=enabled, feature2=enabled by 50% split, feature3=disabled, feature4=enabled by customerId=4```  
+  This configuration can be represented as a scheme.  
+  I was thinking whether this configuration to be part of the standard. See [Slack discussion](https://cloud-native.slack.com/archives/C0344AANLA1/p1684776996586969?thread_ts=1684774617.486109&cid=C0344AANLA1) and example [flagd-definitions](https://github.com/open-feature/schemas/blob/main/json/flagd-definitions.json)
+* Flags registration  
+  Some providers exposing initial flags registration via their SDK. Wondering how does it go with OpenFeature spec.
+

--- a/blog/2023-06-27-openfeature-adoption-story.md
+++ b/blog/2023-06-27-openfeature-adoption-story.md
@@ -102,7 +102,14 @@ sequenceDiagram
   SDK->>request: true/false from cache
 ```
 
-## Misc.
+## Summary
+
+### High Level Adoption
+* Main functionallity used is for evaluating a feature flag value, which fitted our needs.
+* Adopting OpenFeature flag required adding OpenFeature SDK dependency and using it.  
+  As no other major extra steps were needed, it is done via the adoption without containers related changes.
+
+### Challenges
 Some thoughts raised during the adoption:
 * Feature Flags Configuration  
   Considering this as the provider configuration of feature flags, e.g.  
@@ -115,6 +122,7 @@ Some thoughts raised during the adoption:
   This configuration can be represented as a scheme.  
   I was thinking whether this configuration to be part of the standard. If so, it might be beneficial for import/export configurations accross vendors.
   See [Slack discussion](https://cloud-native.slack.com/archives/C0344AANLA1/p1684776996586969?thread_ts=1684774617.486109&cid=C0344AANLA1) and example [flagd-definitions](https://github.com/open-feature/schemas/blob/main/json/flagd-definitions.json).
+* Events - see [Monitoring](#monitoring)
 * Fetch all flags - see [Fetching flags](#fetching-flags)
 * Flags registration  
   Some providers exposing initial flags registration via their SDK. Wondering how does it go with OpenFeature spec.

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -45,3 +45,9 @@ staceypotter:
    title: Program Manager, Open Source Community at Dynatrace
    url: https://github.com/staceypotter
    image_url: https://github.com/staceypotter.png
+
+liran2000:
+  name: Stacey Potter
+  title: Software Developer
+  url: https://liran2000.github.io
+  image_url: https://liran2000.github.io/images/liran.jpg

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -47,7 +47,7 @@ staceypotter:
    image_url: https://github.com/staceypotter.png
 
 liran2000:
-  name: Stacey Potter
+  name: Liran Mendelovich
   title: Software Developer
   url: https://liran2000.github.io
   image_url: https://liran2000.github.io/images/liran.jpg


### PR DESCRIPTION
Add blog post: OpenFeature Adoption Story.

### How to test
- Open the OpenFeature Blog page with all blogs, see the new blog post looks as expected and truncated.
- Press on the new blog post, see new blog post looks as expected. 
